### PR TITLE
Add errno.h lib

### DIFF
--- a/mft/log.c
+++ b/mft/log.c
@@ -26,6 +26,7 @@
 #include <malloc.h>
 #include <unistd.h>
 #include <syslog.h>
+#include <errno.h>
 
 #include "mft.h"
 


### PR DESCRIPTION
Errno.h lib needs to be included after replacing the sys_nerr and sys_errlist by errno and strerror respectively. Now the build works just fine after installing linuxdoc-tools.